### PR TITLE
Updated to not require window, as per Gosu::Image deprecation warning

### DIFF
--- a/lib/gosu_texture_packer.rb
+++ b/lib/gosu_texture_packer.rb
@@ -4,8 +4,8 @@ require 'gosu_texture_packer/tileset'
 
 module Gosu
   module TexturePacker
-    def self.load_json(window, path, mode = :fast)
-      Tileset.load_json(window, path, mode)
+    def self.load_json(path, mode = :fast)
+      Tileset.load_json(path, mode)
     end
   end
 end

--- a/lib/gosu_texture_packer/tileset.rb
+++ b/lib/gosu_texture_packer/tileset.rb
@@ -3,13 +3,12 @@ module Gosu
   module TexturePacker
     class Tileset
 
-      def self.load_json(window, json, mode = :fast)
-        self.new(window, json, mode)
+      def self.load_json(json, mode = :fast)
+        self.new(json, mode)
       end
 
-      def initialize(window, json, mode)
+      def initialize(json, mode)
         @mode = mode
-        @window = window
         @json = JSON.parse(File.read(json))
         @source_dir = File.dirname(json)
         @main_image = build_main_image(mode)
@@ -40,7 +39,7 @@ module Gosu
       def build_main_image(mode)
         case mode
         when :fast
-          Gosu::Image.new(@window, image_file, true)
+          Gosu::Image.new(image_file, { :tileable => true })
         when :precise
           require 'RMagick' unless defined?(Magick)
           Magick::ImageList.new(image_file).first
@@ -53,7 +52,7 @@ module Gosu
         if @mode == :fast
           @main_image.subimage(f['x'], f['y'], f['w'], f['h'])
         else
-          Gosu::Image.new(@window, @main_image, true, f['x'], f['y'], f['w'], f['h'])
+          Gosu::Image.new(@main_image, { :tileable => true, :rect => [f['x'], f['y'], f['w'], f['h']] } )
         end
       end
 

--- a/spec/gosu_texture_packer/tileset_spec.rb
+++ b/spec/gosu_texture_packer/tileset_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Gosu::TexturePacker::Tileset do
   let(:mode) { :fast }
 
   subject(:instance) do
-    tileset_class.load_json(game_window, tileset, mode)
+    tileset_class.load_json(tileset, mode)
   end
 
   shared_examples 'tileset' do
@@ -18,6 +18,10 @@ RSpec.describe Gosu::TexturePacker::Tileset do
     describe '.load_json' do
       it 'loads existing file' do
         expect { subject }.to_not raise_error
+      end
+
+      it 'doesn\'t output Deprecation Warning' do
+        expect { subject }.to_not output.to_stdout
       end
     end
 

--- a/spec/gosu_texture_packer_spec.rb
+++ b/spec/gosu_texture_packer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Gosu::TexturePacker do
 
   describe '.load_json' do
     it 'loads existing file' do
-      expect { Gosu::TexturePacker.load_json(game_window, tileset) }.to_not raise_error
+      expect { Gosu::TexturePacker.load_json(tileset) }.to_not raise_error
     end
   end
 end


### PR DESCRIPTION
Following updates to Gosu::Image, updated to not pass a window reference, as recommended.